### PR TITLE
Update local projectId when creating ES client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -432,7 +432,7 @@ const getElasticsearchClient = async (projectId, secretManager) => {
 
 	const TIMEOUT_10_MINUTES = 10 * 60 * 1000;
 
-	if (projectId === 'local') {
+	if (projectId === 'akeneo-syndication') {
 		return new ElasticsearchClient({
 			node: 'http://localhost:9200',
 		});


### PR DESCRIPTION
We changed our local project id from `local` to `akeneo-syndication` but we never updated fireway so that the ES client correctly targets the local ES